### PR TITLE
Un-break recent actions link

### DIFF
--- a/pops/templates/admin_tools/dashboard/modules/recent_actions.html
+++ b/pops/templates/admin_tools/dashboard/modules/recent_actions.html
@@ -15,7 +15,7 @@
             {{ child.object_repr }}
           </span>
         {% else %}
-          <a href="{{ admin_url }}{{ child.get_admin_url }}"
+          <a href="{{ child.get_admin_url }}"
               class="{% if child.is_addition %} addlink{% endif %}{% if child.is_change %} changelink{% endif %}">
             {% if child.content_type %}
               <span class="content-type">

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='pops',
-    version='0.2.0tt6',
+    version='0.2.0tt7',
     author='Travis Swicegood',
     author_email='travis@domain51.com',
     url='https://github.com/tswicegood/pops',


### PR DESCRIPTION
#### What's this PR do?

Same bugfix as #1347 in TT (https://github.com/texastribune/texastribune/pull/1347)
#### Why are we doing this? How does it help us?

Un-breaks the "recent actions" links in the module in the admin.
#### How should this be manually tested?

See #1347
#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?

n/a
#### What are the relevant tickets?

https://basecamp.com/1866004/projects/1175549/todos/219364008
#### Next steps?

n/a
#### Smells?

See #1347
#### Has the relevant documentation/wiki been updated?

n/a
#### Technical debt note

n/a
